### PR TITLE
Scala 2.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For example:
 
 ```scala
 import com.gu.editorial.permissions.client._
+
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object MyPermissions extends PermissionsProvider {
@@ -69,6 +71,6 @@ Then release to sonatype using [`sbt-sonatype`](https://github.com/xerial/sbt-so
 ```
 sbt
 > clean
-> publishSigned
+> + publishSigned
 > sonatypeRelease
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.3.4",
   "com.typesafe.akka" %% "akka-agent" % "2.3.4",
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.4",
-  "net.liftweb" %% "lift-json" % "2.5",
+  "net.liftweb" %% "lift-json" % "2.6",
   "org.mockito" % "mockito-all" % "1.8.5" % "test",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.4",
   "net.liftweb" %% "lift-json" % "2.5",
   "org.mockito" % "mockito-all" % "1.8.5" % "test",
-  "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
 com.typesafe.sbt.SbtGit.versionWithGit

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -32,9 +32,9 @@ object PermissionsStoreModel {
 }
 
 
-class PermissionsStore(implicit config: PermissionsConfig, executionContext: ExecutionContext) {
+class PermissionsStore(provider: Option[PermissionsStoreProvider] = None)(implicit config: PermissionsConfig, executionContext: ExecutionContext) {
 
-  val storeProvider: PermissionsStoreProvider = new PermissionsStoreFromS3
+  val storeProvider: PermissionsStoreProvider = provider.getOrElse(new PermissionsStoreFromS3)
 
   def get(perm: Permission)(implicit user: PermissionsUser, config: PermissionsConfig): Future[PermissionAuthorisation] =
     list.map(_.getOrElse(perm, perm.defaultValue))

--- a/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
+++ b/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
@@ -5,14 +5,14 @@ import akka.actor.ActorSystem
 import com.amazonaws.AmazonServiceException
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito.when
 import scala.concurrent.{Awaitable, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PermissionsStoreTest extends FunSuite with ShouldMatchers with MockitoSugar with BeforeAndAfterAll {
+class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with BeforeAndAfterAll {
 
   implicit val config = PermissionsConfig("composer", Seq.empty)
 

--- a/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
+++ b/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
@@ -40,7 +40,7 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
   val s3Mock = mock[AmazonS3]
 
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem = ActorSystem("PermissionsStoreTest")
 
   override def afterAll() = actorSystem.shutdown()
 
@@ -127,9 +127,7 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
     mockS3Response(testJson)
 
     val provider = new PermissionsStoreFromS3(refreshFrequency = None, s3Client = Some(s3Mock))
-    val store = new PermissionsStore {
-      override val storeProvider = provider
-    }
+    val store = new PermissionsStore(Some(provider))
 
     await(provider.refreshStore)
 
@@ -148,9 +146,8 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
     when(s3Mock.getContentsAndLastModified(config.s3PermissionsFile, s"${config.s3Bucket}/${config.s3BucketPrefix}")).thenThrow(new AmazonServiceException("Mocked AWS Exception"))
 
-    val store = new PermissionsStore {
-      override val storeProvider = new PermissionsStoreFromS3(s3Client = Some(s3Mock))
-    }
+    val provider = new PermissionsStoreFromS3(s3Client = Some(s3Mock))
+    val store = new PermissionsStore(Some(provider))
 
     implicit val user = PermissionsUser("james", "")
 

--- a/src/test/scala/example/MyPermissions.scala
+++ b/src/test/scala/example/MyPermissions.scala
@@ -1,0 +1,32 @@
+package example
+
+import com.gu.editorial.permissions.client._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object MyPermissions extends PermissionsProvider {
+  val app = "composer"
+
+  implicit def config = PermissionsConfig(
+    app = app,
+    all = all
+  )
+
+  val LaunchContent = Permission("launch_content", app, PermissionGranted)
+
+  val all = Seq(LaunchContent)
+}
+
+object Example {
+
+  implicit def permissionsUser: PermissionsUser =
+    PermissionsUser("user.email@guardian.co.uk", "user-token")
+
+  MyPermissions.get(MyPermissions.LaunchContent).map {
+    case PermissionGranted => "I'm in!"
+    case PermissionDenied => ":("
+  }
+
+  val myPerms: Future[PermissionsMap] = MyPermissions.list
+}


### PR DESCRIPTION
Allow cross-compile to Scala 2.11
- Updates dependencies for Scala 2.11 support
- Cleaned up tests due to new features for Futures in scalatest 2.2.4

Should fix #1 
