### PR TITLE
update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,22 +2,23 @@ name := """editorial-permissions-client"""
 
 organization := "com.gu"
 
-licenses += ("MIT", url("http://opensource.org/licenses/Apache-2.0"))
+licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0"))
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.7"
 
 crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.9.29",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.4",
-  "com.typesafe.akka" %% "akka-agent" % "2.3.4",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.3.4",
-  "net.liftweb" %% "lift-json" % "2.6",
-  "org.mockito" % "mockito-all" % "1.8.5" % "test",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  "com.amazonaws" % "aws-java-sdk-core" % "1.10.37",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.37",
+  "com.typesafe.akka" %% "akka-actor" % "2.4.1",
+  "com.typesafe.akka" %% "akka-agent" % "2.4.1",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.4.1",
+  "net.liftweb" %% "lift-json" % "2.6.2",
+  "org.mockito" % "mockito-all" % "1.10.19" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 )
 
 com.typesafe.sbt.SbtGit.versionWithGit

--- a/build.sbt
+++ b/build.sbt
@@ -10,12 +10,14 @@ crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
 
+val akkaVersion = "2.4.1"
+val awsSdkVersion = "1.10.37"
+
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.10.37",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.37",
-  "com.typesafe.akka" %% "akka-actor" % "2.4.1",
-  "com.typesafe.akka" %% "akka-agent" % "2.4.1",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.4.1",
+  "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  "com.typesafe.akka" %% "akka-agent" % akkaVersion,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
   "net.liftweb" %% "lift-json" % "2.6.2",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test"

--- a/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
+++ b/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
@@ -41,7 +41,7 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
   implicit val actorSystem = ActorSystem("PermissionsStoreTest")
 
-  override def afterAll() = actorSystem.shutdown()
+  override def afterAll() = actorSystem.terminate()
 
   def mockS3Response(response: String) =
     when(s3Mock.getContentsAndLastModified(config.s3PermissionsFile, s"${config.s3Bucket}/${config.s3BucketPrefix}")).thenReturn{ (response, new Date) }


### PR DESCRIPTION
and instead of depending on the entire `aws-java-sdk`, use only `core` and `s3`.

@jamespamplin 
