### PR TITLE
Remove implicit in config and add method to check if store is populated

### DIFF
--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsProvider.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsProvider.scala
@@ -14,7 +14,7 @@ trait PermissionsProvider {
 
   def config: PermissionsConfig
 
-  private val store: PermissionsStore = new PermissionsStore(config)
+  val store: PermissionsStore = new PermissionsStore(config)
 
   def get(perm: Permission)(implicit user: PermissionsUser): Future[PermissionAuthorisation] =
     store.get(perm).recover {

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsProvider.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsProvider.scala
@@ -12,9 +12,9 @@ trait PermissionsProvider {
 
   implicit lazy val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  implicit def config: PermissionsConfig
+  def config: PermissionsConfig
 
-  private val store: PermissionsStore = new PermissionsStore
+  private val store: PermissionsStore = new PermissionsStore(config)
 
   def get(perm: Permission)(implicit user: PermissionsUser): Future[PermissionAuthorisation] =
     store.get(perm).recover {

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -57,6 +57,7 @@ class PermissionsStore(config: PermissionsConfig, provider: Option[PermissionsSt
 
 trait PermissionsStoreProvider {
   val store: Agent[PermissionsStoreModel]
+  def storeIsEmpty: Boolean
 }
 
 
@@ -71,6 +72,13 @@ private[client] final class PermissionsStoreFromS3(config: PermissionsConfig,
   implicit private val timeout = Timeout(Duration(5, SECONDS))
 
   val store: Agent[PermissionsStoreModel] = Agent(PermissionsStoreModel.empty)
+
+  def storeIsEmpty = {
+    store.get() match {
+      case PermissionsStoreModel.empty => true
+      case s: PermissionsStoreModel => false
+    }
+  }
 
   private val s3 = s3Client.getOrElse {
     new AmazonS3(creds = config.awsCredentials, region = config.s3Region)

--- a/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
+++ b/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with BeforeAndAfterAll with ScalaFutures {
 
-  implicit val config = PermissionsConfig("composer", Seq.empty)
+  val config = PermissionsConfig("composer", Seq.empty)
 
   val testJson =
     """
@@ -53,7 +53,7 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
   test("should parse from S3") {
     mockS3Response(testJson)
-    val store = new PermissionsStoreFromS3(refreshFrequency = None, s3Client = Some(s3Mock))
+    val store = new PermissionsStoreFromS3(config, refreshFrequency = None, s3Client = Some(s3Mock))
     val result = store.get
 
     result.defaults.head should be(launchContentPermission)
@@ -82,7 +82,7 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
   test("should refresh store from S3") {
     mockS3Response(testJson)
-    val storeProvider = new PermissionsStoreFromS3(refreshFrequency = None, s3Client = Some(s3Mock))
+    val storeProvider = new PermissionsStoreFromS3(config, refreshFrequency = None, s3Client = Some(s3Mock))
 
     val initStore = storeProvider.store.get()
     initStore.defaults should be(Seq.empty)
@@ -123,8 +123,8 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
   test("should fallback to defaults when overrides not present on a permissions list") {
     mockS3Response(testJson)
 
-    val provider = new PermissionsStoreFromS3(refreshFrequency = None, s3Client = Some(s3Mock))
-    val store = new PermissionsStore(Some(provider))
+    val provider = new PermissionsStoreFromS3(config, refreshFrequency = None, s3Client = Some(s3Mock))
+    val store = new PermissionsStore(config, Some(provider))
 
     provider.refreshStore.futureValue
 
@@ -154,8 +154,8 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
       """.stripMargin
     }
 
-    val provider = new PermissionsStoreFromS3(refreshFrequency = None, s3Client = Some(s3Mock))
-    val store = new PermissionsStore(Some(provider))
+    val provider = new PermissionsStoreFromS3(config, refreshFrequency = None, s3Client = Some(s3Mock))
+    val store = new PermissionsStore(config, Some(provider))
 
     provider.refreshStore.futureValue
 
@@ -177,8 +177,8 @@ class PermissionsStoreTest extends FunSuite with Matchers with MockitoSugar with
 
     when(s3Mock.getContentsAndLastModified(config.s3PermissionsFile, s"${config.s3Bucket}/${config.s3BucketPrefix}")).thenThrow(new AmazonServiceException("Mocked AWS Exception"))
 
-    val provider = new PermissionsStoreFromS3(s3Client = Some(s3Mock))
-    val store = new PermissionsStore(Some(provider))
+    val provider = new PermissionsStoreFromS3(s3Client = Some(s3Mock), config = config)
+    val store = new PermissionsStore(config, Some(provider))
 
     implicit val user = PermissionsUser("james")
 

--- a/src/test/scala/example/MyPermissions.scala
+++ b/src/test/scala/example/MyPermissions.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 object MyPermissions extends PermissionsProvider {
   val app = "composer"
 
-  implicit def config = PermissionsConfig(
+  def config = PermissionsConfig(
     app = app,
     all = all
   )


### PR DESCRIPTION
Composer uses this client library, occassionally on start up it is unable to fetch permissions which has a knock on affect on users being able to do actions. On investigating we decided to do two things here:
1) Remove the implicit config, we think it's clearer to define which config is being used.
2) Added a `storeIsEmpty` which checks if the value in the Agent is populated. Composer uses the  `PermissionsStoreFromS3`. With this value we can then add this to a healthcheck in Composer.
