### PR TITLE
Move info line for fetching from s3 to debug to declutter logs of apps that use this

### DIFF
--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -93,7 +93,7 @@ private[client] final class PermissionsStoreFromS3(config: PermissionsConfig,
     val s3BucketAndPrefix = s"${config.s3Bucket}/${config.s3BucketPrefix}"
     logger.debug(s"Load permissions from S3 bucket: s3://$s3BucketAndPrefix/${config.s3PermissionsFile}")
     val (out, modDate) = s3.getContentsAndLastModified(config.s3PermissionsFile, s3BucketAndPrefix)
-    logger.info(s"Permissions successfully retrieved from S3, last modified: $modDate")
+    logger.debug(s"Permissions successfully retrieved from S3, last modified: $modDate")
     out
   }
 


### PR DESCRIPTION
The default refresh time for fetching permissions is 1 minute. This is causing logs in applications like video to be swamped, moving this log line to debug. If I've understood the code correctly we should be logging out errors when we have exceptions thrown from fetching from S3. 