### PR TITLE
Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,17 +12,17 @@ crossScalaVersions := Seq("2.11.8")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
 
-val akkaVersion = "2.4.7"
-val awsSdkVersion = "1.11.8"
+val akkaVersion = "2.5.9"
+val awsSdkVersion = "1.11.280"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-agent" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-  "net.liftweb" %% "lift-json" % "2.6.3",
+  "net.liftweb" %% "lift-json" % "3.2.0",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )
 
 releaseProcess := Seq[ReleaseStep](

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0"))
 
 scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.11.8")
+crossScalaVersions := Seq("2.11.12")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ organization := "com.gu"
 
 licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0"))
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.11.4")
+crossScalaVersions := Seq("2.11.8")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val awsSdkVersion = "1.11.280"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-  "com.typesafe.akka" %% "akka-agent" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+  "com.gu" %% "box" % "0.2.0",
   "net.liftweb" %% "lift-json" % "3.2.0",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.17

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -42,7 +42,7 @@ class PermissionsStore(config: PermissionsConfig, provider: Option[PermissionsSt
 
   def list(implicit user: PermissionsUser): Future[PermissionsMap] = {
     if (config.enablePermissionsStore)
-      Future.successful(storeProvider.store.get).flatMap {
+      storeProvider.store.get match {
         case PermissionsStoreModel.empty => Future.failed(PermissionsStoreEmptyException())
         case s: PermissionsStoreModel => Future.successful(s.defaultsMap ++ s.userOverrides.getOrElse(user.userId.toLowerCase, Map.empty))
       }

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -42,10 +42,10 @@ class PermissionsStore(config: PermissionsConfig, provider: Option[PermissionsSt
 
   def list(implicit user: PermissionsUser): Future[PermissionsMap] = {
     if (config.enablePermissionsStore)
-      storeProvider.store.modify Try {
-        case PermissionsStoreModel.empty => throw PermissionsStoreEmptyException()
-        case s: PermissionsStoreModel => s.defaultsMap ++ s.userOverrides.getOrElse(user.userId.toLowerCase, Map.empty)
-      }
+      storeProvider.store.modify {
+        case PermissionsStoreModel.empty => Failure(PermissionsStoreEmptyException())
+        case s: PermissionsStoreModel => Success(s)
+      }.map(s => s.defaultsMap ++ s.userOverrides.getOrElse(user.userId.toLowerCase, Map.empty))
 
     else Future.failed(PermissionsStoreDisabledException())
   }

--- a/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
+++ b/src/main/scala/com/gu/editorial/permissions/client/PermissionsStore.scala
@@ -42,10 +42,10 @@ class PermissionsStore(config: PermissionsConfig, provider: Option[PermissionsSt
 
   def list(implicit user: PermissionsUser): Future[PermissionsMap] = {
     if (config.enablePermissionsStore)
-      storeProvider.store.modify {
-        case PermissionsStoreModel.empty => Failure(PermissionsStoreEmptyException())
-        case s: PermissionsStoreModel => Success(s)
-      }.map(s => s.defaultsMap ++ s.userOverrides.getOrElse(user.userId.toLowerCase, Map.empty))
+      Future.successful(storeProvider.store.get).flatMap {
+        case PermissionsStoreModel.empty => Future.failed(PermissionsStoreEmptyException())
+        case s: PermissionsStoreModel => Future.successful(s.defaultsMap ++ s.userOverrides.getOrElse(user.userId.toLowerCase, Map.empty))
+      }
 
     else Future.failed(PermissionsStoreDisabledException())
   }

--- a/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
+++ b/src/test/scala/com/gu/editorial/permissions/client/PermissionsStoreTest.scala
@@ -7,7 +7,7 @@ import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito.when
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
The conundrum:

- `targeting-client` is built for Play 2.6
- `targeting` must then be updated to Play 2.6 in order to use any new version
- sadly, `configuration-magic` for Play 2.6 only exists for Scala 2.12, so `targeting` must be updated to Scala 2.12 too
- ... and `editorial-permissions-client` is built for Scala 2.11 only.

Because Akka Agents are deprecated, I had to use our own `Box` instead. 